### PR TITLE
Update to use WBT backend v1.3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,9 @@ whitebox-python
 .. image:: https://img.shields.io/badge/License-MIT-yellow.svg
         :target: https://opensource.org/licenses/MIT
 
+.. image:: https://img.shields.io/twitter/follow/giswqs?style=social   
+        :target: https://twitter.com/giswqs
+
 .. image:: https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellowgreen.svg
         :target: https://www.buymeacoffee.com/giswqs
 
@@ -179,7 +182,7 @@ When using ``import whitebox``, if you get an error that says ``No module named 
 
 Available Tools
 ---------------
-The library currently contains **435** tools, which are each grouped based on their main function into one of the following categories: Data Tools, GIS Analysis, Hydrological Analysis, Image Analysis, LiDAR Analysis, Mathematical and Statistical Analysis, Stream Network Analysis, and Terrain Analysis. For a listing of available tools, complete with documentation and usage details, please see the `WhiteboxTools User Manual`_.
+The library currently contains **440** tools, which are each grouped based on their main function into one of the following categories: Data Tools, GIS Analysis, Hydrological Analysis, Image Analysis, LiDAR Analysis, Mathematical and Statistical Analysis, Stream Network Analysis, and Terrain Analysis. For a listing of available tools, complete with documentation and usage details, please see the `WhiteboxTools User Manual`_.
 
 
 Supported Data Formats

--- a/whitebox/automation.py
+++ b/whitebox/automation.py
@@ -1,7 +1,7 @@
 ##################################################################
 # Steps for updating the whitebox Python package
-# Step 1 - Delete the existing deveop branch: git branch -D deveop  
-# Step 2 - Create a new deveop branch: git checkout -b deveop
+# Step 1 - Delete the existing develop branch: git branch -D develop  
+# Step 2 - Create a new develop branch: git checkout -b develop
 # Step 3 - Delete the old WhiteboxTools_linux_amd64.tar.xz if needed
 # Step 4 - Run automation.py
 # Step 5 - Create a conda environment: conda create -n wbt python
@@ -83,7 +83,7 @@ with open(os.path.join(WBT_dir, "whitebox_tools.py")) as f_wbt:
     lines = f_wbt.readlines()
     for index, line in enumerate(lines):
         f.write(line)
-        if line.strip() == "from subprocess import CalledProcessError, Popen, PIPE, STDOUT":
+        if line.strip() == "from subprocess import STARTUPINFO, STARTF_USESHOWWINDOW":
             with open(os.path.join(work_dir, "download_wbt.py")) as f_dl:
                 dl_lines = f_dl.readlines()
                 f.writelines(dl_lines[1:])

--- a/whitebox/download_wbt.py
+++ b/whitebox/download_wbt.py
@@ -1,15 +1,17 @@
-import os, sys, platform
-import zipfile
-import tarfile
-import shutil
-import urllib.request
-import pkg_resources
+
 
 
 def download_wbt():
     '''
     Download WhiteboxTools pre-complied binary for first-time use
     '''
+    import os, sys, platform
+    import zipfile
+    import tarfile
+    import shutil
+    import urllib.request
+    import pkg_resources
+
     # print("Your operating system: {}".format(platform.system()))
     package_name = "whitebox"
     # Get package directory
@@ -79,3 +81,4 @@ def download_wbt():
 
 if __name__ == "__main__":
     download_wbt()
+


### PR DESCRIPTION
Dr. [John Lindsay](https://github.com/jblindsay) has updated WhiteboxTools to **v1.3.0**. More information about this version can be found at https://github.com/jblindsay/whitebox-tools/releases/tag/v1.3.0.

- Tools will now output DEFLATE compressed GeoTIFFs when the --compress_rasters parameter is used.
- Added support for a newly developed compressed LiDAR data format, the ZLidar file. All tools
- that accepted LAS file inputs and produced LAS outputs can now use '*.zlidar' files as well. I
- have also added the LasToZlidar and ZlidarToLas tools to perform conversions. While the ZLidar
- format does not yield compression rates quite as good as the popular LAZ file format, you can
- expect ZLidar files to be between 20-30% of the size of the equivalent LAS file. A file
- specification will be published in the near future to describe the open ZLidar data format.
- Added the AsciiToLas tool.
- Added the ContoursFromRaster tool for creating a vector contour coverage from a raster surface model (DEM).
- Added the ContoursFromPoints tool for creating a vector contour coverage from vector points.
- Added the UpdateNodataCells tool.
- Modified the Slope tool to optionally output in degrees, radians, or percent gradient.
- Modified the Mosaic tool, which now runs much faster with large numbers of input tiles.
- The vector-to-raster conversion tools now preserve input projections.
- Fixed a bug in the RasterToVectorPolygons tool.
- Fixed several bugs in the MergeTableWithCsv tool.
- Modified the FillMissingData tool to allow for the exclusion of edge-connected NoData cells from the operation.
- This is better for irregular shaped DEMs that have large areas of NoData surrounding the valid data.
- The LidarConstructVectorTin tool has been depreciated. The tool was not creating the proper output.
- Furthermore, since the number of points in the average LiDAR tile is usually many million, this tool
- would usually produce Shapefiles that exceed the maximum allowable number of shape geometries. If
- a vector TIN is required for a LiDAR point set, users should convert the file to a Shapefile and then
- use the ConstructVectorTin tool instead. And of course, if you are interested in a raster TIN from a
- LiDAR file, use the LidarTinGridding tool instead.
- FlattenLakes now handles multipart lake polygons.