### PR TITLE
CI: Add Python 3.10 and 3.11 jobs, weekly run

### DIFF
--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -5,6 +5,9 @@ on:
     pull_request:
         branches:
             - master
+    workflow_dispatch:
+    schedule:
+        - cron: '0 6 * * 1'
 
 name: py-check
 jobs:
@@ -14,20 +17,21 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                config:
-                    - { os: windows-latest, py: "3.9" }
-                    - { os: macOS-latest, py: "3.9" }
-                    - { os: ubuntu-latest, py: "3.7" }
-                    - { os: ubuntu-latest, py: "3.8" }
-                    - { os: ubuntu-latest, py: "3.9" }
+                os: [ubuntu-latest]
+                py: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+                include:
+                  - os: macos-latest
+                    python-version: "3.10"
+                  - os: windows-latest
+                    python-version: "3.10"
 
         env:
             SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
         steps:
             - name: CHECKOUT CODE
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: SETUP PYTHON
-              uses: actions/setup-python@v1
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.config.py }}
             - name: Install dependencies


### PR DESCRIPTION
A bit of CI maintenance:

- Adds Python 3.10 and 3.11 jobs to the GitHub Action CI build matrix
- It also adds a weekly run each Monday at 06:00 UTC and the ability to manually trigger the CI
- Finally, it updates the checkout and setup-python actions to their latest versions.