### PR TITLE
CI: Use python-version variable everywhere

### DIFF
--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -13,12 +13,12 @@ name: py-check
 jobs:
     py-check:
         runs-on: ${{ matrix.os }}
-        name: ${{ matrix.os }} (${{ matrix.py }})
+        name: ${{ matrix.os }} (${{ matrix.python-version }})
         strategy:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                py: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+                python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
                 include:
                   - os: macos-latest
                     python-version: "3.10"
@@ -33,7 +33,7 @@ jobs:
             - name: SETUP PYTHON
               uses: actions/setup-python@v4
               with:
-                  python-version: ${{ matrix.py }}
+                  python-version: ${{ matrix.python-version }}
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip


### PR DESCRIPTION
I noticed a small bug in the Python version defined in the CI matrix, and fixed it by using `python-version` everywhere instead of sometimes `py`.