### PR TITLE
Fix GLIBC errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 whitebox-python
 ===============
 
+.. image:: https://colab.research.google.com/assets/colab-badge.svg
+        :target: https://gishub.org/whitebox-colab
+
 .. image:: https://mybinder.org/badge_logo.svg 
         :target: https://gishub.org/whitebox-cloud
 
@@ -98,18 +101,21 @@ It is recommended that you use a Python virtual environment (e.g., conda) to tes
   source activate wbt
   conda install whitebox -c conda-forge
 
+If you encounter an GLIBC errors when installing the whitebox package, you can try the following command:
+
+.. code:: python
+
+  import whitebox
+  whitebox.download_wbt(linux_musl=True, reset=True)
+
 
 whitebox Tutorials
 ------------------
 
-Launch the whitebox tutorial notebook directly with **mybinder.org** or **binder.pangeo.io** now:
+Launch the whitebox tutorial notebook directly with **mybinder.org** now:
 
 .. image:: https://mybinder.org/badge_logo.svg 
         :target: https://gishub.org/whitebox-cloud
-
-.. image:: https://binder.pangeo.io/badge.svg 
-        :target: https://binder.pangeo.io/v2/gh/giswqs/whitebox/master?filepath=examples%2Fwhitebox.ipynb
-
 
 Quick Example
 =============

--- a/examples/whitebox.ipynb
+++ b/examples/whitebox.ipynb
@@ -1,11 +1,11 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://gishub.org/whitebox-colab)\n",
-    "[![image](https://binder.pangeo.io/badge_logo.svg)](https://gishub.org/whitebox-pangeo)"
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://gishub.org/whitebox-colab)"
    ]
   },
   {

--- a/whitebox/download_wbt.py
+++ b/whitebox/download_wbt.py
@@ -1,6 +1,11 @@
-def download_wbt(verbose=True):
-    """
-    Download WhiteboxTools pre-complied binary for first-time use
+def download_wbt(linux_musl=False, reset=False, verbose=True):
+    """Downloads WhiteboxTools pre-complied binary for first-time use
+
+    Args:
+        linux_musl (bool, optional): Whether to download the musl version of WhiteboxTools for Linux. Defaults to False.
+        reset (bool, optional): Whether to reset the WhiteboxTools installation. Defaults to False.
+        verbose (bool, optional): Whether to print verbose messages. Defaults to True.
+   
     """
     import glob
     import os
@@ -32,9 +37,13 @@ def download_wbt(verbose=True):
         "Windows": "https://www.whiteboxgeo.com/WBT_Windows/WhiteboxTools_win_amd64.zip",
         "Darwin": "https://www.whiteboxgeo.com/WBT_Darwin/WhiteboxTools_darwin_amd64.zip",
         "Linux": "https://www.whiteboxgeo.com/WBT_Linux/WhiteboxTools_linux_amd64.zip",
+        "Linux-musl": "https://www.whiteboxgeo.com/WBT_Linux/WhiteboxTools_linux_musl.zip"
     }
 
-    # These are backup links only used to pass GitHub automated tests. WhiteboxGeo links frequently encourter timeout errors, which fail the automated tests.
+    if linux_musl:
+        links["Linux"] = links["Linux-musl"]
+
+    # These are backup links only used to pass GitHub automated tests. WhiteboxGeo links frequently encounter timeout errors, which fail the automated tests.
     backup_links = {
         "Windows": "https://github.com/giswqs/whitebox-bin/raw/master/WhiteboxTools_win_amd64.zip",
         "Darwin": "https://github.com/giswqs/whitebox-bin/raw/master/WhiteboxTools_darwin_amd64.zip",
@@ -42,6 +51,10 @@ def download_wbt(verbose=True):
     }
 
     try:
+        if reset:
+            if os.path.exists(exe_dir):
+                shutil.rmtree(exe_dir)
+
         if not os.path.exists(
             exe_dir
         ):  # Download WhiteboxTools executable file if non-existent
@@ -149,7 +162,9 @@ def download_wbt(verbose=True):
             # # which is incompatible with Google Colab that uses GLIBC 2.27. The following code
             # # downloads the binary that is compatible with Google Colab.
             if "google.colab" in sys.modules:
-                url = "https://github.com/giswqs/whitebox-bin/raw/master/WhiteboxTools_ubuntu_18.04.zip"
+                # url = "https://github.com/giswqs/whitebox-bin/raw/master/WhiteboxTools_ubuntu_18.04.zip"
+                url = "https://www.whiteboxgeo.com/WBT_Linux/WhiteboxTools_linux_musl.zip"
+
                 zip_name = os.path.join(pkg_dir, os.path.basename(url))
                 try:
                     request = urllib.request.urlopen(url, timeout=500)

--- a/whitebox/whitebox.py
+++ b/whitebox/whitebox.py
@@ -2,9 +2,9 @@
 
 """Main module."""
 
-from .whitebox_tools import WhiteboxTools
-
+from .whitebox_tools import download_wbt
 
 def Runner(clear_app_state=False, callback=None):
+    from .whitebox_tools import WhiteboxTools
     wbt = WhiteboxTools()
     wbt.launch_wb_runner(clear_app_state, callback)

--- a/whitebox/whitebox.py
+++ b/whitebox/whitebox.py
@@ -2,9 +2,8 @@
 
 """Main module."""
 
-from .whitebox_tools import download_wbt
+from .whitebox_tools import download_wbt, WhiteboxTools
 
 def Runner(clear_app_state=False, callback=None):
-    from .whitebox_tools import WhiteboxTools
     wbt = WhiteboxTools()
     wbt.launch_wb_runner(clear_app_state, callback)


### PR DESCRIPTION
This PR fixes the GLIBC errors #56. Users can run the following code to download the musl-compiled WBT binary to avoid the GLIBC errors.  

```python
import whitebox
whitebox.download_wbt(linux_musl=True, reset=True)
```